### PR TITLE
Patch 4.2.1: Fix to only emit access token and user claims if login was successful

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinchy-co/angular-sdk",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinchy-co/angular-sdk",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/cinchy-co/angular-sdk"

--- a/src/lib/cinchy.service.ts
+++ b/src/lib/cinchy.service.ts
@@ -73,9 +73,11 @@ export class CinchyService {
             that._oAuthService.loadDiscoveryDocumentAndLogin()
             .then(response => {
                 resolve(response);
-                if (emitInfo) {
-                    that.emitAccessToken();
-                    that.emitIdentityClaims();
+                if (response) {
+                    if (emitInfo) {
+                        that.emitAccessToken();
+                        that.emitIdentityClaims();
+                    }
                 }
             })
             .catch(error => {


### PR DESCRIPTION
The issue is that the **emitIdentityClaims()** function calls the **/connect/userInfo** endpoint in the IDP server even if the login wasn't successful yet. This request will always fail when the user hasn't logged in yet and return a 401 error.

The fix will only make the request and emit those claims after the user has successfully logged in.